### PR TITLE
fix/environment-file, use config.js instead of env.js

### DIFF
--- a/src/app/core/services/authentication.service.js
+++ b/src/app/core/services/authentication.service.js
@@ -8,7 +8,6 @@ export default function (app) {
       'ngInject';
 
       this.signUpToFirebase = user => {
-        console.log(user)
         const { email, password } = user;
 
         $rootScope.auth = $firebaseAuth(firebase.auth());

--- a/src/app/index.firebase.config.js
+++ b/src/app/index.firebase.config.js
@@ -3,6 +3,6 @@ import * as firebase from 'firebase';
 import 'angularfire';
 
 // ========= init firebase ========
-import configFirebase from '../../env'
+import configFirebase from '../../config'
 firebase.initializeApp(configFirebase)
 // ================================


### PR DESCRIPTION
There was a bug, because of which useless (*outdated*) file `env.js` was needed. Now only the `config.js` file is used.

Also `console.log()` was deleted from `authentication.service.js`. Because of it the project broke down on `npm start`.